### PR TITLE
require only 3.12.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "opcua-mcp"
 version = "0.1.0"
 description = "An MCP server that connects AI agents to OPC UA-enabled industrial systems."
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.12.2"
 dependencies = [
     "cryptography>=45.0.2",
     "mcp[cli]>=1.5.0",


### PR DESCRIPTION
In my organization we use Python 3.12.2. So I tried and it works fine. So if you want, take this in you solution.